### PR TITLE
[feat] #24 설문 결과 보내고 받아오는 방식 변경

### DIFF
--- a/src/app/_components/SurveyScreen/hooks/usePostSurvey.ts
+++ b/src/app/_components/SurveyScreen/hooks/usePostSurvey.ts
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { postSurvey } from "@/lib/apis/survey";
+import { SurveyRequest } from "@/lib/type";
+
+export function usePostSurvey() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+
+  const router = useRouter();
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    setIsError(false);
+
+    const clientId = localStorage.getItem("userId") || "";
+    const onboarding = JSON.parse(
+      localStorage.getItem("onboardingAnswers") ?? "[]"
+    );
+
+    const payload: SurveyRequest = {
+      clientId,
+      age: Number(onboarding[0]?.substr(0, 2) || 0),
+      gender: onboarding[1],
+      resident: onboarding[2],
+      city: onboarding[3],
+      want: onboarding[5],
+      mood: onboarding[6],
+    };
+
+    try {
+      await postSurvey(payload);
+      router.push("/recommend");
+    } catch (err) {
+      console.error(err);
+      setIsError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { handleSubmit, isLoading, isError };
+}

--- a/src/app/_components/SurveyScreen/index.tsx
+++ b/src/app/_components/SurveyScreen/index.tsx
@@ -4,6 +4,9 @@ import { useSurvey } from "./hooks/useSurvey";
 import ProgressBar from "@/app/_components/SurveyScreen/ProgressBar";
 import SurveyOption from "./SurveyOption";
 import Button from "@/components/Button";
+import clsx from "clsx";
+import { usePostSurvey } from "./hooks/usePostSurvey";
+import ErrorScreen from "@/components/ErrorScreen";
 
 interface SurveyScreenProps {
   type: "onboarding" | "todayMood";
@@ -20,6 +23,13 @@ export default function SurveyScreen({ type, routing }: SurveyScreenProps) {
     handlePrevClick,
     handleNextClick,
   } = useSurvey({ type, routing });
+
+  const { handleSubmit, isLoading, isError } = usePostSurvey();
+
+  const isLastQuestion =
+    type === "todayMood" && currentQuestion === questions.length - 1;
+
+  if (isError) return <ErrorScreen />;
 
   return (
     <div className="flex h-screen w-full flex-col items-center justify-between">
@@ -55,11 +65,14 @@ export default function SurveyScreen({ type, routing }: SurveyScreenProps) {
           )}
           <Button
             color="blue"
-            onClick={handleNextClick}
-            className="text-body-large h-[62px] w-[120px] rounded-xl"
-            disabled={!answers[currentQuestion]}
+            onClick={isLastQuestion ? handleSubmit : handleNextClick}
+            className={clsx(
+              "text-body-large h-[62px] rounded-xl",
+              isLastQuestion ? "w-[166px]" : "w-[120px]"
+            )}
+            disabled={!answers[currentQuestion] || !isLoading}
           >
-            다음
+            {isLastQuestion ? "추천길 보러가기" : "다음"}
           </Button>
         </div>
       </div>

--- a/src/app/recommend/_components/SatisfactionModalContent/hooks/usePatchSatisfaction.ts
+++ b/src/app/recommend/_components/SatisfactionModalContent/hooks/usePatchSatisfaction.ts
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { UpdateRequest } from "@/lib/type";
-import { updateSatisfactionScore } from "@/lib/apis/survey";
+import { SatisfactionRequest } from "@/lib/type";
+import { patchSatisfaction } from "@/lib/apis/survey";
 
-export function useSatisfactionSubmit(onClose: () => void) {
+export function usePatchSatisfaction(onClose: () => void) {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
 
@@ -15,13 +15,13 @@ export function useSatisfactionSubmit(onClose: () => void) {
 
     const clientId = localStorage.getItem("userId") || "";
 
-    const payload: UpdateRequest = {
+    const payload: SatisfactionRequest = {
       clientId,
       satisfactions,
     };
 
     try {
-      await updateSatisfactionScore(payload);
+      await patchSatisfaction(payload);
       onClose();
       router.push("/submit-success");
     } catch (err) {

--- a/src/app/recommend/_components/SatisfactionModalContent/index.tsx
+++ b/src/app/recommend/_components/SatisfactionModalContent/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useSatisfactionSubmit } from "./hooks/useSatisfactionSubmit";
+import { usePatchSatisfaction } from "./hooks/usePatchSatisfaction";
 import SatisfactionForm from "./SatisfactionForm";
 import Button from "@/components/Button";
 import ErrorScreen from "@/components/ErrorScreen";
@@ -11,7 +11,7 @@ export default function SatisfactionModalContent({
 }) {
   const [satisfactionScores, setSatisfactionScores] = useState([0, 0, 0]);
 
-  const { handleSubmit, isLoading, isError } = useSatisfactionSubmit(onClose);
+  const { handleSubmit, isLoading, isError } = usePatchSatisfaction(onClose);
 
   return (
     <div className="flex h-full flex-col gap-8 sm:gap-16">

--- a/src/app/recommend/_hooks/useGetRecommendation.ts
+++ b/src/app/recommend/_hooks/useGetRecommendation.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { fetchRecommendation } from "@/lib/apis/survey";
-import { RecommendationRequest, RecommendationResponse } from "@/lib/type";
+import { getRecommendation } from "@/lib/apis/survey";
+import { RecommendationResponse } from "@/lib/type";
 
-export function useSurveyRecommendation() {
+export function useGetRecommendation() {
   const [spaceData, setSpaceData] = useState<RecommendationResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
@@ -12,22 +12,9 @@ export function useSurveyRecommendation() {
     setIsError(false);
 
     const clientId = localStorage.getItem("userId") || "";
-    const onboarding = JSON.parse(
-      localStorage.getItem("onboardingAnswers") ?? "[]"
-    );
-
-    const payload: RecommendationRequest = {
-      clientId,
-      age: Number(onboarding[0]?.substr(0, 2) || 0),
-      gender: onboarding[1],
-      resident: onboarding[2],
-      city: onboarding[3],
-      want: onboarding[5],
-      mood: onboarding[6],
-    };
 
     try {
-      const res = await fetchRecommendation(payload);
+      const res = await getRecommendation(clientId);
       setSpaceData(res);
     } catch (err) {
       console.error(err);

--- a/src/app/recommend/page.tsx
+++ b/src/app/recommend/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useSurveyRecommendation } from "./_hooks/useSurveyRecommendation";
+import { useGetRecommendation } from "./_hooks/useGetRecommendation";
 import NavBar from "./_components/NavBar";
 import RecommendationPanel from "./_components/RecommendationPanel";
 import MapView from "./_components/MapView";
@@ -13,7 +13,7 @@ import TransitionScreen from "@/app/_components/TransitionScreen";
 export default function RecommendPage() {
   const [isOpen, setIsOpen] = useState(false);
 
-  const { spaceData, isLoading, isError } = useSurveyRecommendation();
+  const { spaceData, isLoading, isError } = useGetRecommendation();
 
   if (isLoading) return <TransitionScreen type="toRecommend" />;
 

--- a/src/lib/apis/survey.ts
+++ b/src/lib/apis/survey.ts
@@ -1,23 +1,33 @@
 import axios from "@/lib/axiosInstance";
-import { RecommendationRequest, UpdateRequest } from "../type";
+import { SurveyRequest, SatisfactionRequest } from "../type";
 
 // 사용자 설문 결과 요청
-export async function fetchRecommendation(payload: RecommendationRequest) {
+export async function postSurvey(payload: SurveyRequest) {
   try {
-    const res = await axios.post("/survey/recommendation", payload);
+    await axios.post("/survey/recommendation", payload);
+  } catch (err) {
+    console.error("사용자 설문 결과 보내기 실패:", err);
+    throw err;
+  }
+}
+
+// 사용자 설문 결과 반환
+export async function getRecommendation(clientId: string) {
+  try {
+    const res = await axios.get(`/survey?clientId=${clientId}`);
     return res.data;
   } catch (err) {
-    console.error("추천 API 실패:", err);
+    console.error("추천 장소 데이터 불러오기 실패:", err);
     throw err;
   }
 }
 
 // 사용자 설문 결과 만족도 반영 요청
-export async function updateSatisfactionScore(payload: UpdateRequest) {
+export async function patchSatisfaction(payload: SatisfactionRequest) {
   try {
     await axios.patch("/survey/update", payload);
   } catch (err) {
-    console.error("만족도 API 호출 실패:", err);
+    console.error("사용자 만족도 조사 결과 보내기 실패:", err);
     throw err;
   }
 }

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -1,4 +1,4 @@
-export interface RecommendationRequest {
+export interface SurveyRequest {
   clientId: string;
   age: number;
   gender: "남자" | "여자";
@@ -20,7 +20,7 @@ export interface RecommendationResponse {
   } | null;
 }
 
-export interface UpdateRequest {
+export interface SatisfactionRequest {
   clientId: string;
   satisfactions: number[];
 }


### PR DESCRIPTION
## 🔗 이슈 번호
Closes #24

<br/>

## 📋 작업 사항
- 설문 마지막 페이지에서 '추천길 보러가기' 버튼 클릭 시 설문 결과 POST 요청 후 `/reommend` 페이지로 이동 : `/api/survey/recommendation`
- `/recommend` 페이지 접근 시 추천 장소 리스트 GET 요청 : `/api/survey?=clientId={clientId}`
